### PR TITLE
Add HTML Documentation to Repository

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,0 +1,46 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+      - name: Create Ontology Documentation
+        run: |
+         sudo apt-get install python3 python3-setuptools python3-pip -y
+         sudo apt-get install gcc libpq-dev -y
+         sudo apt-get install python3-dev python3-pip -y
+         sudo apt-get install asciidoctor ruby -y   
+         sudo gem install --pre asciidoctor-pdf
+         sudo apt-get install python3-venv python3-wheel -y
+         sudo pip3 install wheel pylode==2.13.2 rdflib
+         mkdir docs
+         cd docs
+         echo "Generating documentation for Core ontology"
+         pylode -i ../core_ontology/2024-02-07_nfdi4objects.rdf -o index.html
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@releases/v4
+        with:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+           BRANCH: gh-pages
+           clean: false
+           FOLDER: docs/

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -30,11 +30,11 @@ jobs:
          sudo apt-get install gcc libpq-dev -y
          sudo apt-get install python3-dev python3-pip -y
          sudo apt-get install python3-venv python3-wheel -y
-         sudo pip3 install wheel pylode rdflib
+         sudo pip3 install wheel pylode==2.13.2 rdflib
          mkdir docs
          cd docs
          echo "Generating documentation for Core ontology"
-         python3 -m pylode -o index.html ../core_ontology/2024-02-07_nfdi4objects.rdf
+         pylode -i ../core_ontology/2024-02-07_nfdi4objects.rdf -o index.html
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v4
         with:

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -30,7 +30,7 @@ jobs:
          sudo apt-get install gcc libpq-dev -y
          sudo apt-get install python3-dev python3-pip -y
          sudo apt-get install python3-venv python3-wheel -y
-         sudo pip3 install wheel pylode==2.13.2 rdflib
+         sudo pip3 install wheel pylode rdflib
          mkdir docs
          cd docs
          echo "Generating documentation for Core ontology"

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -29,8 +29,6 @@ jobs:
          sudo apt-get install python3 python3-setuptools python3-pip -y
          sudo apt-get install gcc libpq-dev -y
          sudo apt-get install python3-dev python3-pip -y
-         sudo apt-get install asciidoctor ruby -y   
-         sudo gem install --pre asciidoctor-pdf
          sudo apt-get install python3-venv python3-wheel -y
          sudo pip3 install wheel pylode==2.13.2 rdflib
          mkdir docs

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -34,7 +34,7 @@ jobs:
          mkdir docs
          cd docs
          echo "Generating documentation for Core ontology"
-         pylode -i ../core_ontology/2024-02-07_nfdi4objects.rdf -o index.html
+         python3 -m pylode -o index.html ../core_ontology/2024-02-07_nfdi4objects.rdf
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v4
         with:


### PR DESCRIPTION
I added a pylode HTML documentation which is generated automatically using a Github Actions workflow.
The results are pushed to a branch gh-pages and can subsequently be deployed as a Github page of the repository.
Closes #1 